### PR TITLE
Add return value to callback

### DIFF
--- a/lib/page_transformer.dart
+++ b/lib/page_transformer.dart
@@ -122,6 +122,7 @@ class _PageTransformerState extends State<PageTransformer> {
             viewPortFraction: viewPortFraction,
           );
         });
+          return true;
       },
       child: pageView,
     );


### PR DESCRIPTION
Returning true will cancel the notification bubbling, avoiding unnecessary propagation throughout the Widget tree.